### PR TITLE
fs: readdir: Fix su hide patch for non-iterate filesystems

### DIFF
--- a/fs/readdir.c
+++ b/fs/readdir.c
@@ -37,9 +37,9 @@ int iterate_dir(struct file *file, struct dir_context *ctx)
 
 	res = -ENOENT;
 	if (!IS_DEADDIR(inode)) {
+		ctx->romnt = (inode->i_sb->s_flags & MS_RDONLY);
 		if (file->f_op->iterate) {
 			ctx->pos = file->f_pos;
-			ctx->romnt = (inode->i_sb->s_flags & MS_RDONLY);
 			res = file->f_op->iterate(file, ctx);
 			file->f_pos = ctx->pos;
 		} else {


### PR DESCRIPTION
* 3.10 doesn't normally use iterate for filesystems,
  but it was backported in hopes of removing vfs_readdir()
* Because the romnt variable was only set for filesystems
  using iterate, the su hide patches were broken for many
  filesytems like ext4, which still use vfs_readdir()
  instead of iterate_dir() like their mainline counterparts
* Remove the iterate check around setting romnt to fix this

Change-Id: I26426683df0fd199a80f053294f352e31754bec5